### PR TITLE
Add audio/video cues for answer feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,9 @@
   </main>
 
   <div id="celebration">
-    <video id="goalVideo" src="/assets/messi_goal.mp4" preload="none" playsinline></video>
-    <audio id="cheerAudio" src="/assets/crowd_cheer.mp3" preload="none"></audio>
+    <video id="goalVideo" src="/assets/videoshort.mp4" preload="none" playsinline></video>
+    <audio id="cheerAudio" src="/assets/crowd cheering.mp3" preload="none"></audio>
+    <audio id="booAudio" src="/assets/crowd disappointment.mp3" preload="none"></audio>
   </div>
 
   <script type="module" src="/src/main.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,7 @@ const headerEl = document.getElementById('top');
 const celebrationEl = document.getElementById('celebration');
 const goalVideo = document.getElementById('goalVideo');
 const cheerAudio = document.getElementById('cheerAudio');
+const booAudio = document.getElementById('booAudio');
 
 function resizeCanvas() {
   const rect = canvas.getBoundingClientRect();
@@ -238,6 +239,10 @@ function check() {
     stars = Math.max(0, stars - 1);
     sched.reschedule(card, false, false);
     showNumberLineHint();
+    if (booAudio && booAudio.getAttribute('src')) {
+      booAudio.currentTime = 0;
+      booAudio.play().catch(() => {});
+    }
     speak(`Not quite. ${card.a} times ${card.b} is ${ans}.`, nextQuestion);
   }
   saveProgress();


### PR DESCRIPTION
## Summary
- Play new goal video and cheer audio when answers are correct
- Play disappointment audio when answers are incorrect

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6897c2215930833187aea030dc35a646