### PR TITLE
feat: add server-side usage logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 npm-debug.log*
 dist
 .vite
+usage-log.json
 

--- a/README.md
+++ b/README.md
@@ -9,4 +9,12 @@ npm install
 npm run dev    # start dev server
 npm run build  # produce production bundle
 npm test       # run unit tests
+npm run server # start logging server
 ```
+
+## Usage logging
+
+Run `npm run server` to start a minimal HTTP server that stores usage
+entries in `usage-log.json`. The client posts each session start and
+question result to `/log`. View the accumulated records by visiting
+`http://localhost:3000/logs` or inspecting the `usage-log.json` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "times-table-quest-web",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "devDependencies": {
         "vite": "^7.1.1",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "vitest"
+    "test": "vitest",
+    "server": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,56 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const LOG_FILE = path.join(__dirname, 'usage-log.json');
+
+function appendLog(entry) {
+  let logs = [];
+  try {
+    logs = JSON.parse(fs.readFileSync(LOG_FILE, 'utf8'));
+    if (!Array.isArray(logs)) logs = [];
+  } catch {
+    logs = [];
+  }
+  logs.push(entry);
+  fs.writeFileSync(LOG_FILE, JSON.stringify(logs, null, 2));
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/log') {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+        const entry = { ...data, ip, serverTime: new Date().toISOString() };
+        appendLog(entry);
+        res.writeHead(204).end();
+      } catch {
+        res.writeHead(400).end();
+      }
+    });
+  } else if (req.method === 'GET' && req.url === '/logs') {
+    try {
+      const data = fs.readFileSync(LOG_FILE, 'utf8');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(data);
+    } catch {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end('[]');
+    }
+  } else {
+    res.writeHead(404).end();
+  }
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Logging server running on port ${port}`);
+});

--- a/src/storage.js
+++ b/src/storage.js
@@ -31,4 +31,16 @@ export function appendUsage(entry) {
   } catch {
     /* ignore */
   }
+  try {
+    if (typeof fetch === 'function') {
+      fetch('/log', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(entry),
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch {
+    /* ignore */
+  }
 }


### PR DESCRIPTION
## Summary
- log each session and question to a new Node HTTP server
- forward usage events from the client and document how to view stored logs

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6897c37f82408331ac68c751a4f11aa9