### PR TITLE
Fix usage logging endpoint for usage logs

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -33,7 +33,7 @@ export function appendUsage(entry) {
   }
   try {
     if (typeof fetch === 'function') {
-      fetch('/log', {
+      fetch('/.netlify/functions/log', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(entry),


### PR DESCRIPTION
## Summary
- send usage logs to Netlify function endpoint so events are recorded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e77646e083319759219fdca353c6