### PR TITLE
Add Ronaldo goal easter egg for 4×9 question

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -158,6 +158,12 @@ function nextQuestion() {
   }
   qEl.textContent = `What is ${card.a} × ${card.b} ?`;
   qEl.style.color = stableQuestionColor(card.a, card.b);
+  if (goalVideo) {
+    const src = card.a === 4 && card.b === 9 ? '/assets/ronaldo_.mp4' : '/assets/videoshort.mp4';
+    if (goalVideo.getAttribute('src') !== src) {
+      goalVideo.setAttribute('src', src);
+    }
+  }
   answerEl.disabled = false;
   checkBtn.disabled = false;
   answerEl.value = '';


### PR DESCRIPTION
## Summary
- When the question is 4×9, swap celebration video to `assets/ronaldo_.mp4` as a special Easter egg

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6898cfa0354883319bc60e54c34692a1