### PR TITLE
feat: improve mobile keypad and celebration

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
   <main id="main">
     <div id="question"></div>
     <div id="inputRow">
-      <input id="answer" autocomplete="off" />
+      <input id="answer" type="hidden" />
+      <div id="answerDisplay"></div>
+      <div id="keypad" class="keypad"></div>
       <button id="check">Check</button>
     </div>
     <div id="feedback"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -11,11 +11,11 @@ const TICK_SOUND = false;
 
 const CHEERS = [
   'Well done Albert!',
-  'Good job Bero!',
+  'Good job Biro!',
   'Amazing Albert!',
-  'Great work, Bero!',
+  'Great work, Biro!',
   'Superb, Albert!',
-  'You rock, Bero!',
+  'You rock, Biro!',
 ];
 
 let cards = [];
@@ -35,6 +35,8 @@ const sideEl = document.getElementById('side');
 const timesList = document.getElementById('times');
 const qEl = document.getElementById('question');
 const answerEl = document.getElementById('answer');
+const answerDisplay = document.getElementById('answerDisplay');
+const keypadEl = document.getElementById('keypad');
 const checkBtn = document.getElementById('check');
 const feedbackEl = document.getElementById('feedback');
 const timerEl = document.getElementById('timer');
@@ -51,6 +53,13 @@ const goalVideo = document.getElementById('goalVideo');
 const cheerAudio = document.getElementById('cheerAudio');
 const booAudio = document.getElementById('booAudio');
 const tableSelect = document.getElementById('tableSelect');
+
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 0].forEach((n) => {
+  const btn = document.createElement('button');
+  btn.textContent = String(n);
+  btn.dataset.digit = String(n);
+  keypadEl.appendChild(btn);
+});
 
 function resizeCanvas() {
   const rect = canvas.getBoundingClientRect();
@@ -74,8 +83,14 @@ checkBtn.addEventListener('click', check);
 skipBtn.addEventListener('click', skip);
 exitBtn.addEventListener('click', exitApp);
 toggleHintBtn.addEventListener('click', toggleHint);
-answerEl.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter') check();
+keypadEl.addEventListener('click', (e) => {
+  if (e.target.matches('button')) {
+    const digit = e.target.dataset.digit;
+    if (typeof digit !== 'undefined' && !answerEl.disabled) {
+      answerEl.value += digit;
+      answerDisplay.textContent = answerEl.value;
+    }
+  }
 });
 tableSelect.addEventListener('change', () => {
   init(parseInt(tableSelect.value, 10));
@@ -136,16 +151,16 @@ function saveProgress() {
 
 function speak(text, onDone) {
   if (!('speechSynthesis' in window)) {
-    onDone && onDone();
+    onDone && setTimeout(onDone, 500);
     return;
   }
   const u = new SpeechSynthesisUtterance(text);
   u.rate = 1;
-  u.onend = () => onDone && onDone();
+  u.onend = () => setTimeout(() => onDone && onDone(), 500);
   try {
     window.speechSynthesis.speak(u);
   } catch {
-    onDone && onDone();
+    onDone && setTimeout(onDone, 500);
   }
 }
 
@@ -163,11 +178,16 @@ function nextQuestion() {
     if (goalVideo.getAttribute('src') !== src) {
       goalVideo.setAttribute('src', src);
     }
+    goalVideo.load();
+  }
+  if (cheerAudio) {
+    cheerAudio.load();
   }
   answerEl.disabled = false;
   checkBtn.disabled = false;
   answerEl.value = '';
-  answerEl.focus();
+  answerDisplay.textContent = '';
+  keypadEl.querySelectorAll('button').forEach((b) => (b.disabled = false));
   feedbackEl.textContent = '';
   feedbackEl.style.color = '#93c5fd';
   hintMode = 'placeholder';
@@ -241,7 +261,7 @@ function check() {
   if (!card) return;
   const txt = answerEl.value.trim();
   if (!/^\d+$/.test(txt)) {
-    feedbackEl.textContent = 'Please type a number.';
+    feedbackEl.textContent = 'Please tap a number.';
     return;
   }
   const u = parseInt(txt, 10);
@@ -257,6 +277,7 @@ function check() {
   }
   answerEl.disabled = true;
   checkBtn.disabled = true;
+  keypadEl.querySelectorAll('button').forEach((b) => (b.disabled = true));
   if (u === ans) {
     const msg = CHEERS[Math.floor(Math.random() * CHEERS.length)];
     feedbackEl.textContent = `${msg} (${elapsed.toFixed(1)}s)`;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
-  background: #fffbeb;
-  color: #1f2937;
+  background: #f0f9ff;
+  color: #0f172a;
   font-family: Arial, sans-serif;
   display: flex;
 }
@@ -9,7 +9,7 @@ body {
 #side {
   width: 200px;
   padding: 12px;
-  background: #fff1f2;
+  background: #e0f2fe;
 }
 
 #side h2 {
@@ -31,7 +31,8 @@ header#top {
   top: 0;
   left: 200px;
   right: 0;
-  background: #fde68a;
+  background: #1d4ed8;
+  color: #fff;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -42,7 +43,7 @@ header#top {
 header#top h1 {
   margin: 0;
   font-size: 24px;
-  color: #d97706;
+  color: #fff;
 }
 
 #tablePicker {
@@ -70,18 +71,35 @@ main {
 
 #inputRow {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
-#answer {
+#answerDisplay {
+  font-size: 32px;
+  min-height: 40px;
+  color: #111827;
+}
+
+.keypad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.keypad button {
   font-size: 24px;
-  width: 80px;
-  text-align: center;
+  padding: 12px;
+  margin: 0;
 }
 
 button {
   font-size: 16px;
   padding: 6px 12px;
   margin-left: 6px;
+  color: #fff;
 }
 
 #feedback {
@@ -93,7 +111,7 @@ button {
 #hintCanvas {
   display: block;
   margin: 12px auto;
-  background: #fde68a;
+  background: #e0f2fe;
   width: 100%;
   height: auto;
 }
@@ -107,8 +125,8 @@ button {
 }
 
 button {
-  background: #fcd34d;
-  border: 1px solid #f59e0b;
+  background: #2563eb;
+  border: 1px solid #1e40af;
   border-radius: 4px;
 }
 
@@ -149,8 +167,5 @@ button {
   }
   #question {
     font-size: 24px;
-  }
-  #answer {
-    width: 60px;
   }
 }


### PR DESCRIPTION
## Summary
- Replace text input with on-screen keypad and hide answer field for better iPhone usability
- Load and play celebration video and cheering audio, using Ronaldo clip for 4×9 and giving speech time to finish
- Refresh color palette with higher contrast and update cheers to call Biro by name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689904ebd6ac8331aee203e04c82340d