### PR TITLE
Configure Netlify Blobs access

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 command = "npm run build"
 publish = "dist"
 
+[build.environment]
+  BLOBS_SITE_ID = "dba7a180-9b54-431c-9db9-b261915262ec"
+  BLOBS_TOKEN = "nfp_kHMztNAEv9EPCQJW6mCZ26nzozxWXyiC09ec"
+
 [functions]
 directory = "netlify/functions"
 node_bundler = "esbuild"

--- a/netlify/functions/logs-read.js
+++ b/netlify/functions/logs-read.js
@@ -8,13 +8,12 @@ export async function handler(event) {
   }
 
   const siteID = process.env.BLOBS_SITE_ID
-  const token = process.env.BLOBS_READWRITE_TOKEN
+  const token = process.env.BLOBS_TOKEN || process.env.BLOBS_READWRITE_TOKEN
 
   if (!siteID || !token) {
     return {
       statusCode: 500,
-      body:
-        'Missing Netlify Blob configuration. Set BLOBS_SITE_ID and BLOBS_READWRITE_TOKEN.',
+      body: 'Missing Netlify Blob configuration. Set BLOBS_SITE_ID and BLOBS_TOKEN.',
     }
   }
 


### PR DESCRIPTION
## Summary
- support BLOBS_TOKEN env var in logs-read function
- set BLOBS_SITE_ID and BLOBS_TOKEN in Netlify config

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ab61dbb4188331b343d63021a0b8c6