### PR TITLE
Ensure dist directory exists for Netlify deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  publish = "."
+  publish = "dist"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "netlify dev",
-    "build": "echo 'Static site - no build step'"
+    "build": "rm -rf dist && mkdir -p dist && cp -r index.html submissions.html style.css assets public src dist"
   },
   "dependencies": {
     "@netlify/blobs": "^8.0.0"


### PR DESCRIPTION
## Summary
- generate `dist` output via build script so Netlify has a deploy directory
- configure Netlify to publish from `dist`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab84102ca4833190a39f702f64dfa1