### PR TITLE
fix: remove nonexistent public dir from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "netlify dev",
-    "build": "rm -rf dist && mkdir -p dist && cp -r index.html submissions.html style.css assets public src dist"
+    "build": "rm -rf dist && mkdir -p dist && cp -r index.html submissions.html style.css assets src dist"
   },
   "dependencies": {
     "@netlify/blobs": "^8.0.0"


### PR DESCRIPTION
## Summary
- avoid copying missing `public` directory in build script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab888454dc8331a4809f3dcf2e3265