### PR TITLE
Improve UI contrast, mobile layout, and submission logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     </div>
     <div id="status">Streak 0 | Stars 0 | Mastered 0/0</div>
     <div id="timer">0.0s</div>
+    <a id="usageLink" href="/submissions.html">Usage logs</a>
   </header>
 
   <main id="main">
@@ -58,8 +59,6 @@
     <audio id="cheerAudio" src="/assets/crowd cheering.mp3" preload="none"></audio>
     <audio id="booAudio" src="/assets/crowd disappointment.mp3" preload="none"></audio>
   </div>
-
-  <a href="/submissions.html">View usage logs</a>
 
   <script type="module" src="/src/main.js"></script>
   <script type="module">

--- a/src/main.js
+++ b/src/main.js
@@ -422,13 +422,10 @@ function drawNumberLine() {
 }
 
 function render() {
-  bgHue = (bgHue + 0.0015) % 1;
-  const bg = hsvToHex(bgHue, 0.2, 0.95);
-  const panel = hsvToHex((bgHue + 0.08) % 1, 0.15, 0.9);
-  document.body.style.background = bg;
-  sideEl.style.background = bg;
-  headerEl.style.background = panel;
-  canvas.style.background = panel;
+  document.body.style.background = '#ffffff';
+  sideEl.style.background = '#f1f5f9';
+  headerEl.style.background = '#1e3a8a';
+  canvas.style.background = '#f1f5f9';
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   if (hintMode === 'array') drawArray();

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
-  background: #f0f9ff;
-  color: #0f172a;
+  background: #ffffff;
+  color: #000000;
   font-family: Arial, sans-serif;
   display: flex;
 }
@@ -9,7 +9,7 @@ body {
 #side {
   width: 200px;
   padding: 12px;
-  background: #e0f2fe;
+  background: #f1f5f9;
 }
 
 #side h2 {
@@ -31,11 +31,13 @@ header#top {
   top: 0;
   left: 200px;
   right: 0;
-  background: #1d4ed8;
+  background: #1e3a8a;
   color: #fff;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 8px 16px;
   box-sizing: border-box;
 }
@@ -63,6 +65,12 @@ header#top h1 {
 
 #timer {
   font-weight: bold;
+  margin-left: auto;
+}
+
+#usageLink {
+  color: #fff;
+  text-decoration: underline;
 }
 
 main {
@@ -109,6 +117,9 @@ button {
   padding: 6px 12px;
   margin-left: 6px;
   color: #fff;
+  background: #1d4ed8;
+  border: 1px solid #1e40af;
+  border-radius: 4px;
 }
 
 #feedback {
@@ -120,7 +131,7 @@ button {
 #hintCanvas {
   display: block;
   margin: 12px auto;
-  background: #e0f2fe;
+  background: #f1f5f9;
   width: 100%;
   height: auto;
 }
@@ -131,12 +142,6 @@ button {
   align-items: center;
   gap: 8px;
   margin-top: 8px;
-}
-
-button {
-  background: #2563eb;
-  border: 1px solid #1e40af;
-  border-radius: 4px;
 }
 
 #celebration {
@@ -169,6 +174,8 @@ button {
     position: static;
     left: 0;
     right: 0;
+    flex-direction: column;
+    align-items: flex-start;
   }
   main {
     margin-left: 0;
@@ -176,5 +183,22 @@ button {
   }
   #question {
     font-size: 24px;
+  }
+  #timer {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  header#top h1 {
+    font-size: 20px;
+  }
+  #tablePicker label,
+  #tablePicker select {
+    font-size: 18px;
+  }
+  .keypad button {
+    font-size: 20px;
+    padding: 10px;
   }
 }

--- a/submissions.html
+++ b/submissions.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Submissions Log</title>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 2rem; }
+    body { font-family: system-ui, sans-serif; margin: 2rem; background: #ffffff; color: #000; }
     table { border-collapse: collapse; width: 100%; }
-    th, td { border: 1px solid #ccc; padding: .5rem; text-align: left; }
-    th { background: #f7f7f7; position: sticky; top: 0; }
+    th, td { border: 1px solid #666; padding: .5rem; text-align: left; }
+    th { background: #e2e8f0; position: sticky; top: 0; }
     .muted { color: #666; font-size: .9em; }
     #login { margin-bottom: 1rem; }
   </style>
@@ -21,10 +21,11 @@
   </div>
   <p class="muted">Showing the most recent 500 events.</p>
   <table>
-    <thead><tr><th>Time (EST)</th><th>IP</th><th>Event</th><th>Meta</th></tr></thead>
+    <thead><tr><th>Question</th><th>Answer</th><th>Time (s)</th><th>Result</th></tr></thead>
     <tbody id="rows"><tr><td colspan="4">No data loaded.</td></tr></tbody>
   </table>
   <script>
+    const FAST_THRESHOLD_SEC = 3.0;
     async function load() {
       const pw = document.getElementById('pwd').value;
       const el = document.getElementById('rows');
@@ -35,20 +36,26 @@
           return;
         }
         const data = await res.json();
-        if (!Array.isArray(data) || data.length === 0) {
+        const answers = Array.isArray(data) ? data.filter(e => e.event === 'answer').reverse() : [];
+        if (answers.length === 0) {
           el.innerHTML = '<tr><td colspan="4">No events yet.</td></tr>';
           return;
         }
-        el.innerHTML = data.reverse().map(e => {
-          const meta = Object.assign({}, e);
-          const ts = meta.ts; delete meta.ts;
-          const ip = meta.ip; delete meta.ip;
-          const ev = meta.event; delete meta.event;
+        el.innerHTML = answers.map(e => {
+          const parts = (e.question || '').split('×');
+          const a = parseInt(parts[0], 10);
+          const b = parseInt(parts[1], 10);
+          const correctAns = a * b;
+          const given = parseInt(e.answer, 10);
+          const correct = given === correctAns;
+          const fast = correct && e.elapsed <= FAST_THRESHOLD_SEC;
+          const result = correct ? (fast ? '✅⚡' : '✅') : '✖';
+          const elapsed = typeof e.elapsed === 'number' ? e.elapsed.toFixed(1) : '';
           return `<tr>
-            <td>${ts || ''}</td>
-            <td>${ip || ''}</td>
-            <td>${ev || ''}</td>
-            <td><pre style="margin:0;white-space:pre-wrap">${JSON.stringify(meta, null, 2)}</pre></td>
+            <td>${e.question || ''}</td>
+            <td>${e.answer || ''}</td>
+            <td>${elapsed}</td>
+            <td>${result}</td>
           </tr>`;
         }).join('');
       } catch (err) {


### PR DESCRIPTION
## Summary
- Add usage logs link to top header
- Increase color contrast and refine layout for mobile, especially iPhones
- Redesign submissions log table with question, answer, time, and result icons

## Testing
- `npm run build`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e2dd27883318154010e7b8c8fce