### PR TITLE
Add metadata to submissions log and improve hint contrast

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -338,7 +338,7 @@ function tickTimer() {
 setInterval(tickTimer, TIMER_INTERVAL_MS);
 
 function drawPlaceholder() {
-  ctx.fillStyle = '#e5e7eb';
+  ctx.fillStyle = '#1f2937';
   ctx.font = '16px sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText('Try it in your head…', canvas.width / 2, 40);
@@ -367,7 +367,7 @@ function drawArray() {
       ctx.fill();
     }
   }
-  ctx.fillStyle = '#e5e7eb';
+  ctx.fillStyle = '#1f2937';
   ctx.font = '14px sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText(`${rows} rows × ${cols} columns`, w / 2, 22);
@@ -381,7 +381,7 @@ function drawNumberLine() {
   const h = canvas.height;
   const pad = 40;
   const y = h / 2;
-  ctx.strokeStyle = '#ffffff';
+  ctx.strokeStyle = '#334155';
   ctx.lineWidth = 3;
   ctx.beginPath();
   ctx.moveTo(pad, y);
@@ -395,7 +395,7 @@ function drawNumberLine() {
     ctx.moveTo(x, y - 8);
     ctx.lineTo(x, y + 8);
     ctx.stroke();
-    ctx.fillStyle = '#e5e7eb';
+    ctx.fillStyle = '#1f2937';
     ctx.font = '12px sans-serif';
     ctx.textAlign = 'center';
     ctx.fillText(String(i * a), x, y + 22);
@@ -415,7 +415,7 @@ function drawNumberLine() {
     ctx.textAlign = 'center';
     ctx.fillText(`+${a}`, xm, y - 42);
   }
-  ctx.fillStyle = '#e5e7eb';
+  ctx.fillStyle = '#1f2937';
   ctx.font = '14px sans-serif';
   ctx.textAlign = 'center';
   ctx.fillText(`Number line: ${a} repeated ${b} times = ${total}`, w / 2, 22);
@@ -425,7 +425,7 @@ function render() {
   document.body.style.background = '#ffffff';
   sideEl.style.background = '#f1f5f9';
   headerEl.style.background = '#1e3a8a';
-  canvas.style.background = '#f1f5f9';
+  canvas.style.background = '#ffffff';
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   if (hintMode === 'array') drawArray();

--- a/style.css
+++ b/style.css
@@ -131,7 +131,7 @@ button {
 #hintCanvas {
   display: block;
   margin: 12px auto;
-  background: #f1f5f9;
+  background: #ffffff;
   width: 100%;
   height: auto;
 }

--- a/submissions.html
+++ b/submissions.html
@@ -21,8 +21,8 @@
   </div>
   <p class="muted">Showing the most recent 500 events.</p>
   <table>
-    <thead><tr><th>Question</th><th>Answer</th><th>Time (s)</th><th>Result</th></tr></thead>
-    <tbody id="rows"><tr><td colspan="4">No data loaded.</td></tr></tbody>
+    <thead><tr><th>IP</th><th>Time (EST)</th><th>Event</th><th>Question</th><th>Answer</th><th>Time (s)</th><th>Result</th></tr></thead>
+    <tbody id="rows"><tr><td colspan="7">No data loaded.</td></tr></tbody>
   </table>
   <script>
     const FAST_THRESHOLD_SEC = 3.0;
@@ -32,26 +32,30 @@
       try {
         const res = await fetch('/.netlify/functions/list?password=' + encodeURIComponent(pw));
         if (res.status === 401) {
-          el.innerHTML = '<tr><td colspan="4">Unauthorized</td></tr>';
+          el.innerHTML = '<tr><td colspan="7">Unauthorized</td></tr>';
           return;
         }
         const data = await res.json();
-        const answers = Array.isArray(data) ? data.filter(e => e.event === 'answer').reverse() : [];
-        if (answers.length === 0) {
-          el.innerHTML = '<tr><td colspan="4">No events yet.</td></tr>';
+        const events = Array.isArray(data) ? data.slice(-500).reverse() : [];
+        if (events.length === 0) {
+          el.innerHTML = '<tr><td colspan="7">No events yet.</td></tr>';
           return;
         }
-        el.innerHTML = answers.map(e => {
-          const parts = (e.question || '').split('×');
+        el.innerHTML = events.map(e => {
+          const isAnswer = e.event === 'answer';
+          const parts = (isAnswer && e.question || '').split('×');
           const a = parseInt(parts[0], 10);
           const b = parseInt(parts[1], 10);
           const correctAns = a * b;
           const given = parseInt(e.answer, 10);
-          const correct = given === correctAns;
+          const correct = isAnswer && given === correctAns;
           const fast = correct && e.elapsed <= FAST_THRESHOLD_SEC;
-          const result = correct ? (fast ? '✅⚡' : '✅') : '✖';
-          const elapsed = typeof e.elapsed === 'number' ? e.elapsed.toFixed(1) : '';
+          const result = isAnswer ? (correct ? (fast ? '✅⚡' : '✅') : '✖') : '';
+          const elapsed = isAnswer && typeof e.elapsed === 'number' ? e.elapsed.toFixed(1) : '';
           return `<tr>
+            <td>${e.ip || ''}</td>
+            <td>${e.ts || ''}</td>
+            <td>${e.event || ''}</td>
             <td>${e.question || ''}</td>
             <td>${e.answer || ''}</td>
             <td>${elapsed}</td>
@@ -59,7 +63,7 @@
           </tr>`;
         }).join('');
       } catch (err) {
-        el.innerHTML = `<tr><td colspan="4">Failed to load logs</td></tr>`;
+        el.innerHTML = `<tr><td colspan="7">Failed to load logs</td></tr>`;
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- Display IP, timestamp, and event type in submissions table
- Darken hint canvas text and lines for better color contrast

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab9979651c8331b80a0c7ef06de8c2